### PR TITLE
Instructions for using TeX Live 2017

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
 .SUFFIXES: .tex .in .dvi .ps .pdf
-all: thesis.pdf 
-.tex.pdf: 
-	pdflatex $<
+all: thesis.pdf
+.tex.pdf:
+	xelatex $<
 	-bibtex $*
-	pdflatex $<
-	pdflatex $<
+	xelatex $<
+	xelatex $<
 introduction.pdf:
-	pdflatex introduction.tex
+	xelatex introduction.tex
 	bibtex introduction.aux
-	pdflatex introduction.tex
-	pdflatex introduction.tex
+	xelatex introduction.tex
+	xelatex introduction.tex
 chapter1.pdf: chapter1
-	pdflatex chapter1/chapter1.tex
+	xelatex chapter1/chapter1.tex
 	bibtex chapter1.aux
-	pdflatex chapter1/chapter1.tex
-	pdflatex chapter1/chapter1.tex
+	xelatex chapter1/chapter1.tex
+	xelatex chapter1/chapter1.tex
 chapter2.pdf: chapter2
-	pdflatex chapter2/chapter2.tex
+	xelatex chapter2/chapter2.tex
 	bibtex chapter2.aux
-	pdflatex chapter2/chapter2.tex
-	pdflatex chapter2/chapter2.tex
+	xelatex chapter2/chapter2.tex
+	xelatex chapter2/chapter2.tex
 conclusion.pdf:
-	pdflatex conclusion.tex
+	xelatex conclusion.tex
 	bibtex conclusion.aux
-	pdflatex conclusion.tex
-	pdflatex conclusion.tex
+	xelatex conclusion.tex
+	xelatex conclusion.tex
 clean:
 	rm -f *.aux *.dvi *.ps *.bbl *.blg *.out *.log *.toc *.lof *.lot *.nav *.snm *.bak *~ *.acn *.ist *.syg *.acn *.glsdefs *.ist *.syg thesis.pdf introduction.pdf chapter1.pdf chapter2.pdf conclusion.pdf

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I also have a makefile that compiles chapters separately (with bibliography), so
 
 Use Tex Live 2017 for correct spacing.  
 On Mac,
-* Download MacTex 2017 (`mactex-date.pkg` and `mactex-ghostscript-version/date.pkg`) from [here](http://ftp.math.utah.edu/pub/tex/historic/systems/mactex/)
+* Download [MacTex](http://www.tug.org/mactex/index.html) 2017 (`mactex-date.pkg` and `mactex-ghostscript-version/date.pkg`) from [here](http://ftp.math.utah.edu/pub/tex/historic/systems/mactex/)
 * Install `mactex.pkg` and then `ghostscript.pkg`
 * Open the GUI software, TeX Live Utility, and change the version to be used to 2017. Goto `Configure` --> `Change Default Tex Live Version ...`
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
+# UPenn CIS PhD Thesis Template
 This project has the Thesis template for UPenn CIS students, that I got by modifying the template [here](https://guides.library.upenn.edu/dissertation_manual/formatting).
-As far as I can tell by inspecting earlier theses before me, this template is correct. 
+As far as I can tell by inspecting earlier theses before me, this template is correct.
 
-I have organized chapters into folders so that all `.tex` files relevant to a certain chapter remain in one place. 
+I have organized chapters into folders so that all `.tex` files relevant to a certain chapter remain in one place.
 
-I also have a makefile that compiles chapters separately (with bibliography), so that you can quickly compile the chapter you are working on, without compiling the entire thesis. 
+I also have a makefile that compiles chapters separately (with bibliography), so that you can quickly compile the chapter you are working on, without compiling the entire thesis.
 
+## Tex Live Version
+**!!! Using Tex Live 2020 leads to incorrect spacing (e.g. no space around section title) !!!**
+
+Use Tex Live 2017 for correct spacing.  
+On Mac,
+* Download MacTex 2017 (`mactex-date.pkg` and `mactex-ghostscript-version/date.pkg`) from [here](http://ftp.math.utah.edu/pub/tex/historic/systems/mactex/)
+* Install `mactex.pkg` and then `ghostscript.pkg`
+* Open the GUI software, TeX Live Utility, and change the version to be used to 2017. Goto `Configure` --> `Change Default Tex Live Version ...`
+
+Confirm the version using  `xelatex --version`
 
 ### Compile Entire Thesis
 
-Ensure that the correct biblio setting is active, 
+Ensure that the correct biblio setting is active,
 
 ```latex
 %% TO TURN ON BIB FOR CHAPTER (when compiling chapters separately)
@@ -17,16 +28,16 @@ Ensure that the correct biblio setting is active,
 \def\biblio{}
 ```
 
-And then run 
+And then run
 
 ```
 make clean; make
 ```
 
 ### Compile Chapter Separately
-To compile a single chapter for proofreading. 
+To compile a single chapter for proofreading.
 
-Ensure that the correct biblio setting is active, 
+Ensure that the correct biblio setting is active,
 
 ```latex
 %% TO TURN ON BIB FOR CHAPTER (when compiling chapters separately)
@@ -35,7 +46,7 @@ Ensure that the correct biblio setting is active,
 % \def\biblio{}
 ```
 
-And then run 
+And then run
 
 ```
 make clean; make chapter1.pdf


### PR DESCRIPTION
Also updated to using `xelatex` instead of `pdflatex`